### PR TITLE
empty check for number of points in a lane in extract_descriptors

### DIFF
--- a/main.ipynb
+++ b/main.ipynb
@@ -242,7 +242,7 @@
     "        single_lane = label.eq(i).view(-1).nonzero().squeeze()\n",
     "        \n",
     "        # As they could be not continuous, skip the ones that have no points\n",
-    "        if single_lane.numel() == 0:\n",
+    "        if single_lane.numel() == 0 or len(single_lane.size()) == 0:\n",
     "            continue\n",
     "        \n",
     "        # Points to sample to fill a squared desciptor\n",


### PR DESCRIPTION
Fix for #11 
empty check for number of points in a lane in extract_descriptors
